### PR TITLE
Mover AccuWeatherAPI a un package para poder importarlo

### DIFF
--- a/src/main/java/edu/utn/frba/dds/accuweather/AccuWeatherAPI.java
+++ b/src/main/java/edu/utn/frba/dds/accuweather/AccuWeatherAPI.java
@@ -1,3 +1,5 @@
+package edu.utn.frba.dds.accuweather;
+
 import java.util.*;
 
 public final class AccuWeatherAPI {


### PR DESCRIPTION
Para QMP4 probé de usar [jitpack.io](https://jitpack.io/) para agregar este repo como dependencia y [funcionó](https://github.com/RaniAgus/dds-jv-2022-que-me-pongo/blob/33b49b1c93fa1665915a38a60c858ad7e474e2ae/pom.xml#L21-L33) 😄 

La forma de hacerlo es, dado un tag de Git (ej: `1.0.0`), agregar lo siguiente al pom.xml:

```xml
  <repositories>
    <repository>
      <id>jitpack.io</id>
      <url>https://jitpack.io</url>
    </repository>
  </repositories>

  <dependencies>
    <dependency>
      <groupId>com.github.dds-utn</groupId>
      <artifactId>api-accuweather-objetos</artifactId>
      <version>1.0.0</version>
    </dependency>
    <!-->
      ...
    <!-->
  </dependencies>
```

El PR se debe a que tuve que mover la clase a un package para poder hacer el `import`.